### PR TITLE
Prepare slipstream package release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
 </a>
 
 ```shell
-pip install litellm
+pip install litellm-slipstream-fork
 ```
 
 ```python
@@ -219,7 +219,7 @@ The proxy provides:
 ## Quick Start Proxy - CLI
 
 ```shell
-pip install 'litellm[proxy]'
+pip install 'litellm-slipstream-fork[proxy]'
 ```
 
 ### Step 1: Start litellm proxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "litellm"
+name = "litellm-slipstream-fork"
 version = "1.74.0"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]


### PR DESCRIPTION
## Summary
- rename Poetry package to `litellm-slipstream-fork`
- update installation instructions in README

## Testing
- `pytest -q test_url_encoding.py`

------
https://chatgpt.com/codex/tasks/task_e_687d50b082688323b7cd4fd2f98d2143